### PR TITLE
Fix: pluginManagement tag on quiche4j-jni project

### DIFF
--- a/quiche4j-jni/pom.xml
+++ b/quiche4j-jni/pom.xml
@@ -23,6 +23,7 @@
     </properties>
 
     <build>
+    <pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -69,6 +70,7 @@
                 </executions>
             </plugin>
         </plugins>
+        </pluginManagement>
     </build>
 
 </project>


### PR DESCRIPTION
This PR contains a fix on `pom.xml` file related to the `quiche4j-jni` project. There has missing a tag called `pluginManagment`, and it was generating an error when the user tries to build the project (manually or automatically) using `mvn clean install`.

Error: 
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:3.0.0:run (build-native-lib) on project quiche4j-jni: An Ant BuildException has occured: exec returned: 101
[ERROR] around Ant part ...<exec resolveexecutable="false" failonerror="true" executable="cargo">... @ 4:75 in /home/James/quiche4j/quiche4j-jni/target/antrun/build-main.xml
```