### PR TITLE
Feature: Enable returning streamId when sending a request with additional body data

### DIFF
--- a/quiche4j-core/src/main/java/io/quiche4j/http3/Http3Connection.java
+++ b/quiche4j-core/src/main/java/io/quiche4j/http3/Http3Connection.java
@@ -39,8 +39,8 @@ public final class Http3Connection {
     /**
      * @see sendRequest(Http3Header[], boolean)
      */
-    public final void sendRequest(List<Http3Header> headers, boolean fin) {
-        sendRequest(headers.toArray(new Http3Header[0]), fin);
+    public final long sendRequest(List<Http3Header> headers, boolean fin) {
+        return sendRequest(headers.toArray(new Http3Header[0]), fin);
     }
 
     /**
@@ -58,8 +58,8 @@ public final class Http3Connection {
      * happens the application should retry the operation once the stream is reported
      * as writable again.
      */
-    public final void sendRequest(Http3Header[] headers, boolean fin) {
-        Http3Native.quiche_h3_send_request(getPointer(), conn.getPointer(), headers, fin);
+    public final long sendRequest(Http3Header[] headers, boolean fin) {
+        return Http3Native.quiche_h3_send_request(getPointer(), conn.getPointer(), headers, fin);
     }
 
     /**

--- a/quiche4j-jni/src/lib.rs
+++ b/quiche4j-jni/src/lib.rs
@@ -819,11 +819,12 @@ pub extern "system" fn Java_io_quiche4j_http3_Http3Native_quiche_1h3_1send_1requ
     h3_ptr: jlong,
     conn_ptr: jlong,
     headers: jobjectArray,
+    fin: jboolean,
 ) {
     let h3_conn = unsafe { &mut *(h3_ptr as *mut h3::Connection) };
     let mut conn = unsafe { &mut *(conn_ptr as *mut Connection) };
     let req = headers_from_java(&env, headers).unwrap();
-    h3_conn.send_request(&mut conn, &req, true).unwrap();
+    h3_conn.send_request(&mut conn, &req, fin != 0).unwrap();
 }
 
 #[no_mangle]


### PR DESCRIPTION
The `README.md` suggests using the following snippet to send a request with additional body data:

```
final long streamId = h3Conn.sendRequest(req, false);
h3Conn.sendBody(streamId, "Hello there!".getBytes(), true);
```

This does not work because `h3Conn.sendRequest()` returns `void` instead of a `long`-type stream ID. 

This PR passes the `fin` boolean to the JNI call instead of a hardcoded `true` and returns the stream ID.